### PR TITLE
Fix Heat Map grand-total column label on the Reduction Potential view

### DIFF
--- a/utils/queries.py
+++ b/utils/queries.py
@@ -1164,7 +1164,7 @@ def create_heatmap_sql(country_selected_bool,
         table_join = ""
         field = "country_name "
 
-    if sum_column == "Reduction Potential":
+    if sum_column == "total_emissions_reduced_per_year":
         alias = 'total_reduction_potential'
     else:
         alias = 'total_emissions_quantity'


### PR DESCRIPTION
This PR proposes fixing the Heat Map's grand-total column, which is named `total_emissions_quantity` even when the Reduction Potential metric is selected. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/332. You can sign in with your GitHub ID to claim ownership of the project.

## What's wrong

`create_heatmap_sql()` in `utils/queries.py` names its grand-total column by testing the metric **label**:

```python
if sum_column == "Reduction Potential":
    alias = 'total_reduction_potential'
else:
    alias = 'total_emissions_quantity'
```

Its only caller, `tabs/tab06_reduction_heatmap.py`, passes the metric **column name** instead — `total_emissions_reduced_per_year` or `emissions_quantity` — so the first branch is unreachable and `alias` is always `total_emissions_quantity`. The earlier call is still commented out just above it at `tab06_reduction_heatmap.py:146-154` and passes `selected_metric=selected_metric`, so the switch to `sum_column` looks like where the comparison was left behind; `excluded_cols` at `tab06_reduction_heatmap.py:233` also still lists `total_reduction_potential`, a column name the current code can no longer produce.

`"Reduction Potential"` is the first entry in the `Select Metric` dropdown, so this is what the Heat Map shows on open: a grand-total column headed `total_emissions_quantity` that is actually carrying reduction potential. Both rendered tables and the CSV a user pulls off them carry that header.

## Reproducing on `main` (c29223c)

```python
import duckdb
from config import CONFIG
from utils.queries import create_heatmap_sql

con = duckdb.connect()
kw = dict(annual_asset_path=CONFIG['annual_asset_path'],
          gadm_1_path=CONFIG['gadm_1_path'], gadm_2_path=CONFIG['gadm_2_path'],
          country_selected_bool=False, state_selected_bool=False, g20_bool=False,
          region_condition=None, selected_state_province=None, gas='co2e_100yr')

# the two values tab06 maps the "Select Metric" dropdown to before calling
for metric, sum_column in [("Reduction Potential", "total_emissions_reduced_per_year"),
                           ("Emissions Quantity",  "emissions_quantity")]:
    df = con.execute(create_heatmap_sql(sum_column=sum_column, **kw)['sector_summary']).df()
    total_col = df.columns[-2]
    print(f'{metric!r} -> {total_col!r} = {df[total_col].iloc[0]:,.0f}')
```

Output before the change — two different quantities under one column name:

```
'Reduction Potential' -> 'total_emissions_quantity' = 31,993,310,584
'Emissions Quantity'  -> 'total_emissions_quantity' = 72,839,288,956
```

After the change:

```
'Reduction Potential' -> 'total_reduction_potential' = 31,993,310,584
'Emissions Quantity'  -> 'total_emissions_quantity'  = 72,839,288,956
```

## The change

One line, in `create_heatmap_sql()`: compare `sum_column` against the column it actually receives. That restores `total_reduction_potential`, which is already the name `summarize_ers_sql` gives the same quantity at `utils/queries.py:970` (`ROUND(SUM(total_emissions_reduced_per_year), 0) AS total_reduction_potential`). No figure moves — only the header. The Global + Emissions Quantity view is untouched, since that path reads the precomputed `heatmap_global_*` parquet rather than this builder, and its column is correctly named already.

## How I verified it

The repo documents having no automated tests, so I checked it against the app itself, on Python 3.12 with your pinned `requirements.txt` and the parquet files in `data/`:

- every page in `pages/` plus `app.py` rendered through Streamlit's own `AppTest` harness, before and after — all render, no new exceptions;
- `pages/3_Heat_Map.py` rendered end to end at its default selections, reading the column names straight off the two `st.dataframe` calls: `total_emissions_quantity` before, `total_reduction_potential` after, with identical values;
- module import smoke over `tabs/` and `utils/`, and a `pyflakes` run — output identical to the pre-change baseline.

## How this was managed

This work was tracked on a live board imported from this repository — 95 stories built from your pull requests — and the story carrying this fix is https://eastagiletracker.com/projects/332/stories/214262 on the board at https://eastagiletracker.com/projects/332. It was picked up and moved across that board as the change was made.

![board](https://raw.githubusercontent.com/eastagiletracker/emissions-reduction-pathways-dashboard/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
